### PR TITLE
Indsupplering af et nyt bestyrelsesmedlem foretages ved afgørelse i den eksisterende bestyrelse.

### DIFF
--- a/vedtaegter.tex
+++ b/vedtaegter.tex
@@ -158,10 +158,14 @@ poster.
 
 \item Bestyrelsen er selvsupplerende.
 
+\begin{substykenum}
+
+    \item Indsupplering af et nyt bestyrelsesmedlem foretages ved afgørelse i den eksisterende bestyrelse.
+     
+\end{substykenum}
+
 \item Afgørelser inden for bestyrelsen træffes ved almindeligt flertal.
 Ved stemmelighed bortfalder forslaget.
-
-
 
 \item Formand og kasserer, ved ophørt tilhørsforhold til DIKU kan ved
 indstemmelse til en (evt. ekstraordinær) generalforsamling forblive


### PR DESCRIPTION
For at sikre, at medlemmer af bestyrelsen ved, hvad det indebærer, og at de er interesserede i at være en aktiv del af kantinen.