### PR TITLE
Ethvert bestyrelsesmedlem skal besidde mindst én ansvarspost.

### DIFF
--- a/vedtaegter.tex
+++ b/vedtaegter.tex
@@ -169,6 +169,8 @@ som medlemmer i foreningen i op til 3 måneder efter ophør, og kan
 forblive ved sin post i den periode, med henblik på overdragelse af
 posterne og fuldmagterne.
 
+\item Ethvert bestyrelsesmedlem skal besidde mindst én ansvarspost.
+
 \end{stykenum}
 
 \section{Generalforsamling}


### PR DESCRIPTION
På baggrund af drøftelserne på bestyrelsesmødet den 18. februar 2025 blev det ønsket, at bestyrelsen formindskes i et forsøg på at gøre den beslutningsdygtig til flere møder. For at opnå dette skal der være et krav om, at alle medlemmer har en ansvarspost.