### PR TITLE
Fjern krav om indkaldelse til GF på mailinglister

### DIFF
--- a/vedtaegter.tex
+++ b/vedtaegter.tex
@@ -181,10 +181,10 @@ posterne og fuldmagterne.
 
 \item Indkaldelse til ordinær generalforsamling skal ske med mindst to
 ugers varsel, med en uges frist til at indsende forslag til optagelse
-på dagsordenen. Forslag, der skal behandles på en generalforsamling
+på dagsordenen. Forslag, der skal behandles på en generalforsamling,
 skal stå på dagsordenen. Dagsordenen offentliggøres mindst tre dage
 før generalforsamlingen. Indkaldelse og dagsorden offentliggøres både
-på de relevante mailinglister og ved opslag i kantinen.
+på kantinens relevante nyhedskanaler og ved opslag i kantinen.
 
 \item Ekstraordinær generalforsamling kan indkaldes, når to
 bestyrelsesmed\-lemmer eller 20 af medlemmerne ønsker det. For den


### PR DESCRIPTION
Kantineforeningen har ikke længere mailinglister, hvor det kunne give mening for os at indkalde til generalforsamlinger. Derfor har vi i år også valgt i bestyrelsen ikke at overholde denne vedtægt.