### PR TITLE
Fjern paragraf om endt tilhørsforhold

### DIFF
--- a/vedtaegter.tex
+++ b/vedtaegter.tex
@@ -116,9 +116,9 @@ selv.
 \item Med\-lemmerne er forpligtet til ved deres arbejde at medvirke
 til kantinens drift, som beskrevet i ordensreglerne for brug af
 kantinen, som forefindes på kantineforeningens hjemmeside.
-\item Ophører et
-medlems tilhørsforhold til instituttet, ophører medlemskabet
-ligeledes.
+\item Ophører et medlems tilhørsforhold til instituttet, ophører deres
+medlemskab ligeledes, medmindre bestyrelsen beslutter at lade
+medlemskabet fortsætte indtil næste generalforsamling.
 \item Såfremt et medlems opførsel skønnes at være i konflikt med
 ordensreglerne kan bestyrelsen (i samråd med instituttets le\-delse)
 ophæve dennes medlemskab midlertidigt eller permanent.
@@ -160,14 +160,6 @@ poster.
 
 \item Afgørelser inden for bestyrelsen træffes ved almindeligt flertal.
 Ved stemmelighed bortfalder forslaget.
-
-
-
-\item Formand og kasserer, ved ophørt tilhørsforhold til DIKU kan ved
-indstemmelse til en (evt. ekstraordinær) generalforsamling forblive
-som medlemmer i foreningen i op til 3 måneder efter ophør, og kan
-forblive ved sin post i den periode, med henblik på overdragelse af
-posterne og fuldmagterne.
 
 \end{stykenum}
 


### PR DESCRIPTION
Det er meget kort tid kun at måtte blive i Kantinebestyrelsen i op til 3 måneder efter endt tilhørsforhold til DIKU, endda kun under betingelse af at det lykkes at afholde en generalforsamling. Der risikeres at gå meget viden tabt, hvis det ikke når at blive overdraget.

Det virker derfor bedre at lade bestyrelsen vurdere, om medlemmers medlemskab må fortsætte indtil næste generalforsamling. Dette er mere i stil med specialmedlemskaber, som tildeles i f.eks. RusKursusGruppen og på Caféen?.