### PR TITLE
Fjern krav om valg af revisorer

### DIFF
--- a/vedtaegter.tex
+++ b/vedtaegter.tex
@@ -298,6 +298,9 @@ foretages \\ lodtrækning.
 
 \item Valget gælder for det indeværende års regnskaber. Valg foregår efter
 samme princip som for bestyrelsen.
+
+\item Hvis der ikke vælges revisorer, kan bestyrelsen (jf. \ref*{bestyrelsen-ledelse}) selv vælge, hvordan regnskabet revideres.
+
 \end{stykenum}
 
 \section{Vederlag}


### PR DESCRIPTION
Hvis denne ændring gennemføres uden at ændre driften til at være underlagt RusKursusGruppen, skal referencen til den paragraf rettes.